### PR TITLE
Added missing property "children" to action object

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -179,7 +179,8 @@ var ReportContainer = Base.extend(
 				data: {},
 				messages: [],
 				parentId: parentId,
-				output: {}
+				output: {},
+				children: []
 			};
 
 			parent = this.getAction(parentId);


### PR DESCRIPTION
I was getting errors like these:

```
TypeError: Cannot read property 'push' of undefined
    at testStart (.../node_modules/preceptor-reporter/lib/container.js:190:19)
    at .testStart (.../node_modules/preceptor-core/lib/utils.js:108:34)
    at processMessage (.../node_modules/preceptor-reporter/lib/manager.js:519:28)
    at .processMessage (.../node_modules/preceptor-core/lib/utils.js:108:34)
    at .<anonymous> (.../node_modules/preceptor/lib/abstractForkTask.js:151:34)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at process.nextTick (internal/child_process.js:744:12)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

This PR fixes it.
